### PR TITLE
Convert to using Expeditor for hab build

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,0 +1,2 @@
+[nginx-demo]
+paths = []

--- a/.expeditor/buildkite/kubernetes.sh
+++ b/.expeditor/buildkite/kubernetes.sh
@@ -18,7 +18,7 @@ DEBUG=${DEBUG:-false}
 # This block translates the "environment" into the appropriate Habitat
 # channel from which we'll deploy from
 if [ "$ENVIRONMENT" == "acceptance" ]; then
-  export CHANNEL=acceptance
+  export CHANNEL=dev
 elif [ "$ENVIRONMENT" == "production" ]; then
   export CHANNEL=stable
 elif [ "$ENVIRONMENT" == "dev" ]; then

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -32,7 +32,7 @@ pipelines:
 subscriptions:
   - workload: docker_image_published:chefops/nginx-demo:*
     actions:
-    - trigger_pipeline:deploy/acceptance
+      - trigger_pipeline:deploy/acceptance
 
 promote:
   action:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -4,6 +4,15 @@ slack:
 github:
   delete_branch_on_merge: true
 
+habitat_packages:
+  - nginx-demo:
+      origin: chefops
+      export:
+        - docker
+
+merge_actions:
+  - built_in:trigger_habitat_package_build
+
 pipelines:
   - verify:
       description: Pull Request validation tests
@@ -20,14 +29,14 @@ pipelines:
         - ENVIRONMENT: production
         - APP: nginx-demo
 
+subscriptions:
+  - workload: docker_image_published:chefops/nginx-demo:*
+    actions:
+    - trigger_pipeline:deploy/acceptance
+
 promote:
   action:
     - bash:.expeditor/promote.sh
-    - trigger_pipeline:deploy/acceptance:
-        only_if_conditions:
-          - value_one: "{{target_channel}}"
-            operator: equals
-            value_two: acceptance
     - trigger_pipeline:deploy/production:
         only_if_conditions:
           - value_one: "{{target_channel}}"


### PR DESCRIPTION
This commit changes the workflow to use Expeditor for performing the
Habitat package build and publishing to Docker Hub instead of Builder
itself.

This will automatically deploy to acceptance on a merge to master, and
then we can promote to production with the Slack command.