### PR TITLE
use acceptance, rather than latest

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -30,7 +30,7 @@ pipelines:
         - APP: nginx-demo
 
 subscriptions:
-  - workload: docker_image_published:chefops/nginx-demo:latest
+  - workload: docker_image_published:chefops/nginx-demo:acceptance
     actions:
       - trigger_pipeline:deploy/acceptance
 

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=nginx-demo
 pkg_origin=chefops
-pkg_version="0.2.2"
+pkg_version="0.2.3"
 pkg_maintainer="Chef Operations <ops@chef.io>"
 pkg_deps=(core/nginx core/curl)
 pkg_svc_user="root"


### PR DESCRIPTION
We won't have a latest tag because the hab export done by expeditor
uses `--no-tag-latest`. It will default to the acceptance channel,
however, based on the list of channels in the expeditor configuration.