### PR TITLE
trigger_pipeline can now work with docker_image_published

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=nginx-demo
 pkg_origin=chefops
-pkg_version="0.2.3"
+pkg_version="0.2.4"
 pkg_maintainer="Chef Operations <ops@chef.io>"
 pkg_deps=(core/nginx core/curl)
 pkg_svc_user="root"


### PR DESCRIPTION
Increment the version in the habitat plan so we can run through the
pipeline and get the triggered action when the docker image is
published with the acceptance tag.