### PR TITLE
use acceptance for CHANNEL, remove namespace creation

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=nginx-demo
 pkg_origin=chefops
-pkg_version="0.2.4"
+pkg_version="0.2.5"
 pkg_maintainer="Chef Operations <ops@chef.io>"
 pkg_deps=(core/nginx core/curl)
 pkg_svc_user="root"


### PR DESCRIPTION
We aren't using the "dev" channel for promotion anymore, and instead
go straight into acceptance automatically.

Also, we don't need to manage the namespace in the kubernetes.sh
script as we've added it to the yaml configuration.